### PR TITLE
Move NSS and LDAP configuration out of auth recipe

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -5,20 +5,12 @@ provisioner:
   name: chef_zero
 
 platforms:
-  - name: centos-6.7
-  - name: centos-7.2
-  - name: debian-7.10
-    run_list: apt::default
-  - name: debian-8.4
-    run_list: apt::default
-  - name: fedora-21
-  - name: fedora-22
-  - name: ubuntu-12.04
-    run_list: apt::default
   - name: ubuntu-14.04
     run_list: apt::default
-  - name: freebsd-10.1
-    run_list: freebsd::pkgng
+  - name: ubuntu-16.04
+    run_list: apt::default
+  - name: ubuntu-18.04
+    run_list: apt::default
 
 suites:
 - name: server

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -69,3 +69,18 @@ suites:
      shadow_ou: ninjas
      group_ou: pirates
      automount_ou: barge
+- name: nss_test
+  run_list:
+  - recipe[openldap::nss]
+  attributes:
+    openldap:
+      server_uri: 'ldap://ldap.example.com'
+      basedn: "dc=example, dc=com"
+      nss_base:
+        passwd:
+          - "ou=people, dc=example, dc=com"
+        shadow:
+          - "ou=people, dc=example, dc=com"
+        group:
+          - "ou=group, dc=example, dc=com"
+      tls_enabled: false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -105,7 +105,7 @@ default['openldap']['basedn'] = 'dc=localdomain'
 default['openldap']['cn'] = 'admin'
 default['openldap']['server'] = 'ldap.localdomain'
 default['openldap']['port'] = 389
-default['openldap']['server_uri'] = "ldap://#{openldap['server']}/"
+default['openldap']['server_uri'] = "ldap://#{node['openldap']['server']}/"
 default['openldap']['tls_enabled'] = true
 
 # The NSS filters here determine what users and groups the machine knows about
@@ -136,10 +136,10 @@ default['openldap']['pam_hash']['session']['required'] = ['pam_unix.so', 'pam_mk
 
 default['openldap']['manage_ssl'] = false
 default['openldap']['tls_checkpeer'] = false
-default['openldap']['ssl_dir'] = "#{openldap['dir']}/ssl"
+default['openldap']['ssl_dir'] = "#{node['openldap']['dir']}/ssl"
 default['openldap']['cafile']  = nil
-default['openldap']['ssl_cert'] = "#{openldap['ssl_dir']}/#{openldap['server']}_cert.pem"
-default['openldap']['ssl_key'] = "#{openldap['ssl_dir']}/#{openldap['server']}.pem"
+default['openldap']['ssl_cert'] = "#{node['openldap']['ssl_dir']}/#{node['openldap']['server']}_cert.pem"
+default['openldap']['ssl_key'] = "#{node['openldap']['ssl_dir']}/#{node['openldap']['server']}.pem"
 default['openldap']['ssl_cert_source_cookbook'] = 'openldap'
 default['openldap']['ssl_cert_source_path'] = "ssl/#{node['openldap']['server']}_cert.pem"
 default['openldap']['ssl_key_source_cookbook'] = 'openldap'
@@ -166,7 +166,7 @@ default['openldap']['server_config_hash']['sizelimit'] = 500
 
 default['openldap']['client_config_hash']['ldap_version'] = 3
 default['openldap']['client_config_hash']['bind_policy'] = 'soft'
-default['openldap']['client_config_hash']['pam_password'] = openldap['pam_password']
+default['openldap']['client_config_hash']['pam_password'] = node['openldap']['pam_password']
 
 # package settings
 default['openldap']['package_install_action'] = :install

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -66,8 +66,8 @@ end
 # packages
 case node['platform_family']
 when 'debian'
-  # precise and up and wheezy and up stopped putting the version name in the db-util package.
-  # this is required to keep support for lucid
+  # precise and up and wheezy and up stopped putting the version name
+  # in the db-util package. this is required to keep support for lucid
   default['openldap']['packages']['bdb'] = if node['platform'] == 'ubuntu' && node['platform_version'].to_i < 12
                                              'db4.8-util'
                                            else
@@ -77,6 +77,7 @@ when 'debian'
   default['openldap']['packages']['srv_pkg'] = 'slapd'
   default['openldap']['packages']['nss'] = 'libnss-ldap'
   default['openldap']['packages']['auth_pkgs'] = %w(libpam-ldap)
+  default['openldap']['package_install_options'] = '--no-install-recommends'
 when 'rhel'
   default['openldap']['packages']['bdb'] = 'db4-utils'
   default['openldap']['packages']['client_pkg'] = 'openldap-clients'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -75,22 +75,26 @@ when 'debian'
                                            end
   default['openldap']['packages']['client_pkg'] = 'ldap-utils'
   default['openldap']['packages']['srv_pkg'] = 'slapd'
-  default['openldap']['packages']['auth_pkgs'] = %w(libnss-ldap libpam-ldap)
+  default['openldap']['packages']['nss'] = 'libnss-ldap'
+  default['openldap']['packages']['auth_pkgs'] = %w(libpam-ldap)
 when 'rhel'
   default['openldap']['packages']['bdb'] = 'db4-utils'
   default['openldap']['packages']['client_pkg'] = 'openldap-clients'
   default['openldap']['packages']['srv_pkg'] = 'openldap-servers'
+  default['openldap']['packages']['nss'] = %w(nss-pam-ldapd)
   default['openldap']['packages']['auth_pkgs'] = %w(nss-pam-ldapd)
 when 'freebsd'
   default['openldap']['packages']['bdb'] = 'libdbi'
   default['openldap']['packages']['client_pkg'] = 'openldap-client'
   default['openldap']['packages']['srv_pkg'] = 'openldap-server'
+  default['openldap']['packages']['nss'] = 'openldap-client'
   default['openldap']['packages']['auth_pkgs'] = %w(pam_ldap)
 else
   default['openldap']['packages']['bdb'] = 'db-utils'
   default['openldap']['packages']['client_pkg'] = 'ldap-utils'
   default['openldap']['packages']['srv_pkg'] = 'slapd'
-  default['openldap']['packages']['auth_pkgs'] = %w(libnss-ldap libpam-ldap)
+  default['openldap']['packages']['nss'] = 'libnss-ldap'
+  default['openldap']['packages']['auth_pkgs'] = %w(libpam-ldap)
 end
 
 #

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'cookbooks@chef.io'
 license           'Apache 2.0'
 description       'Configures a server to be an OpenLDAP master, replication slave or client for auth'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '2.2.6'
+version           '2.2.7'
 
 recipe            'openldap',         'Empty, use one of the other recipes'
 recipe            'openldap::nss',    'Set up openldap for NSS'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'cookbooks@chef.io'
 license           'Apache 2.0'
 description       'Configures a server to be an OpenLDAP master, replication slave or client for auth'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '2.2.4'
+version           '2.2.5'
 
 recipe            'openldap',         'Empty, use one of the other recipes'
 recipe            'openldap::nss',    'Set up openldap for NSS'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'cookbooks@chef.io'
 license           'Apache 2.0'
 description       'Configures a server to be an OpenLDAP master, replication slave or client for auth'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '2.2.3'
+version           '2.2.4'
 
 recipe            'openldap',         'Empty, use one of the other recipes'
 recipe            'openldap::nss',    'Set up openldap for NSS'
@@ -12,7 +12,7 @@ recipe            'openldap::auth',   'Set up openldap for user authentication'
 recipe            'openldap::client', 'Install openldap client packages'
 recipe            'openldap::server', 'Set up openldap to be a slapd server'
 recipe            'openldap::slave',  'Uses search to set replication slave attributes'
-recipe            'openldap::master',   'Use on nodes that should be a slapd master'
+recipe            'openldap::master', 'Use on nodes that should be a slapd master'
 
 %w(ubuntu debian freebsd redhat centos amazon scientific oracle).each do |os|
   supports os

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'cookbooks@chef.io'
 license           'Apache 2.0'
 description       'Configures a server to be an OpenLDAP master, replication slave or client for auth'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '2.2.5'
+version           '2.2.6'
 
 recipe            'openldap',         'Empty, use one of the other recipes'
 recipe            'openldap::nss',    'Set up openldap for NSS'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,14 +4,15 @@ maintainer_email  'cookbooks@chef.io'
 license           'Apache 2.0'
 description       'Configures a server to be an OpenLDAP master, replication slave or client for auth'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '2.2.1'
+version           '2.2.3'
 
 recipe            'openldap',         'Empty, use one of the other recipes'
+recipe            'openldap::nss',    'Set up openldap for NSS'
 recipe            'openldap::auth',   'Set up openldap for user authentication'
 recipe            'openldap::client', 'Install openldap client packages'
 recipe            'openldap::server', 'Set up openldap to be a slapd server'
 recipe            'openldap::slave',  'Uses search to set replication slave attributes'
-recipe            'openldap::master', 'Use on nodes that should be a slapd master'
+recipe            'openldap::master',   'Use on nodes that should be a slapd master'
 
 %w(ubuntu debian freebsd redhat centos amazon scientific oracle).each do |os|
   supports os

--- a/recipes/nss.rb
+++ b/recipes/nss.rb
@@ -20,6 +20,10 @@
 
 include_recipe 'openldap::client'
 
+package node['openldap']['packages']['nss'] do
+  action node['openldap']['package_install_action']
+end
+
 template '/etc/ldap.conf' do
   source 'ldap.conf.erb'
   mode '0644'

--- a/recipes/nss.rb
+++ b/recipes/nss.rb
@@ -22,6 +22,7 @@ include_recipe 'openldap::client'
 
 package node['openldap']['packages']['nss'] do
   action node['openldap']['package_install_action']
+  options node['openldap']['package_install_options']
 end
 
 template '/etc/ldap.conf' do

--- a/test/cookbooks/openldap-test/recipes/ssl.rb
+++ b/test/cookbooks/openldap-test/recipes/ssl.rb
@@ -6,7 +6,7 @@ end
 directory node[:openldap][:ssl_dir] do
   owner 'root'
   group 'root'
-  mode 00755
+  mode '0755'
   action :create
 end
 
@@ -16,6 +16,6 @@ node[:certs].each do |c|
     action :create_if_missing
     owner 'root'
     group 'root'
-    mode 0644
+    mode '0644'
   end
 end


### PR DESCRIPTION
### Description

The Name Service Switch and LDAP client now configured in the `nss` recipe.
### Issues Resolved
### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD
